### PR TITLE
Add public getter/setter for token/endpoint

### DIFF
--- a/src/Session/GoogleSession.php
+++ b/src/Session/GoogleSession.php
@@ -89,8 +89,12 @@ class GoogleSession extends Session {
     $this->token = $auth['Auth'];
   }
 
-  protected function getToken() {
+  public function getToken() {
     return $this->token;
+  }
+
+  public function setToken($token) {
+    $this->token = $token;
   }
 
   public function getProvider() {

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -54,7 +54,7 @@ abstract class Session {
   abstract public function authenticate();
   abstract public function getProvider();
   abstract public function getToken();
-  abstract public function setToken();
+  abstract public function setToken($token);
 
   protected function getDefaultRequests() {
     $reqs = [];

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -37,6 +37,10 @@ abstract class Session {
     return $this->endpoint;
   }
 
+  public function setEndpoint($endpoint) {
+    $this->endpoint = $endpoint;
+  }
+
   public function setLocation($lat, $long, $alt) {
     $this->lat = $lat;
     $this->long = $long;
@@ -49,7 +53,8 @@ abstract class Session {
 
   abstract public function authenticate();
   abstract public function getProvider();
-  abstract protected function getToken();
+  abstract public function getToken();
+  abstract public function setToken();
 
   protected function getDefaultRequests() {
     $reqs = [];


### PR DESCRIPTION
You would usually want to cache these, right? To avoid authentication on every request. No need to cache ourselves, but this makes it possible for users to add some caching.
